### PR TITLE
Add helper functions exported by Transform class

### DIFF
--- a/prosemirror/transform/transform.py
+++ b/prosemirror/transform/transform.py
@@ -5,6 +5,8 @@ from .mark_step import AddMarkStep, RemoveMarkStep
 from .replace import close_fragment, covered_depths, fits_trivially, replace_step
 from .replace_step import ReplaceAroundStep, ReplaceStep
 from .structure import can_change_type, insert_point
+from . import structure
+from . import replace
 
 
 class TransformError(ValueError):
@@ -12,6 +14,16 @@ class TransformError(ValueError):
 
 
 class Transform:
+    # functions from .structure exposed by Transform
+    join_point = structure.join_point
+    can_join = structure.can_join
+    can_split = structure.can_split
+    insert_point = structure.insert_point
+    drop_point = structure.drop_point
+    lift_target = structure.lift_target
+    find_wrapping = structure.find_wrapping
+    replace_step = replace.replace_step
+
     def __init__(self, doc):
         self.doc = doc
         self.steps = []


### PR DESCRIPTION
Per the ProseMirorr documentation [here](https://prosemirror.net/docs/ref/#transform.replaceStep), the Transform class should expose some helper functions from the transform/structure and transform/replace modules. This commit makes those functions available as essentially class static methods of the Transform class to match the docs. 