### PR TITLE
Translation of DOMSerializer

### DIFF
--- a/prosemirror/model/__init__.py
+++ b/prosemirror/model/__init__.py
@@ -5,6 +5,7 @@ from .node import Node
 from .replace import ReplaceError, Slice
 from .resolvedpos import NodeRange, ResolvedPos
 from .schema import MarkType, NodeType, Schema
+from .to_dom import DOMSerializer
 
 __all__ = [
     "Node",
@@ -18,4 +19,5 @@ __all__ = [
     "NodeType",
     "MarkType",
     "ContentMatch",
+    "DOMSerializer",
 ]

--- a/prosemirror/model/to_dom.py
+++ b/prosemirror/model/to_dom.py
@@ -19,6 +19,26 @@ class DocumentFragment:
 
 
 class Element(DocumentFragment):
+    self_closing_elements = frozenset(
+        [
+            "area",
+            "base",
+            "br",
+            "col",
+            "embed",
+            "hr",
+            "img",
+            "input",
+            "keygen",
+            "link",
+            "meta",
+            "param",
+            "source",
+            "track",
+            "wbr",
+        ]
+    )
+
     def __init__(self, name: str, attrs: Dict[str, str], children: List[HTMLNode]):
         self.name = name
         self.attrs = attrs
@@ -28,8 +48,11 @@ class Element(DocumentFragment):
         attrs_str = " ".join(
             [f'{k}="{escape_attr_value(v)}"' for k, v in self.attrs.items()]
         )
-        children_str = "".join([str(c) for c in self.children])
         open_tag_str = " ".join([s for s in [self.name, attrs_str] if s])
+        if self.name in self.self_closing_elements:
+            assert not self.children, "self-closing elements should not have children"
+            return f"<{open_tag_str}>"
+        children_str = "".join([str(c) for c in self.children])
         return f"<{open_tag_str}>{children_str}</{self.name}>"
 
 

--- a/prosemirror/model/to_dom.py
+++ b/prosemirror/model/to_dom.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import cast, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from . import Fragment, Mark, Node, Schema
@@ -11,18 +10,19 @@ def escape_attr_value(s: str) -> str:
     return s.replace('"', '\\"')
 
 
-@dataclass
 class DocumentFragment:
-    children: List[HTMLNode]
+    def __init__(self, children: List[HTMLNode]):
+        self.children = children
 
     def __str__(self):
         return "".join([str(c) for c in self.children])
 
 
-@dataclass
 class Element(DocumentFragment):
-    name: str
-    attrs: Dict[str, str]
+    def __init__(self, name: str, attrs: Dict[str, str], children: List[HTMLNode]):
+        self.name = name
+        self.attrs = attrs
+        super().__init__(children)
 
     def __str__(self):
         attrs_str = " ".join(
@@ -36,10 +36,14 @@ class Element(DocumentFragment):
 HTMLOutputSpec = Union[str, tuple, Element]
 
 
-@dataclass
 class DOMSerializer:
-    nodes: Dict[str, Callable[[Node], HTMLOutputSpec]]
-    marks: Dict[str, Callable[[Mark, bool], HTMLOutputSpec]]
+    def __init__(
+        self,
+        nodes: Dict[str, Callable[[Node], HTMLOutputSpec]],
+        marks: Dict[str, Callable[[Mark, bool], HTMLOutputSpec]],
+    ):
+        self.nodes = nodes
+        self.marks = marks
 
     def serialize_fragment(
         self, fragment: Fragment, target: Optional[Element] = None

--- a/prosemirror/model/to_dom.py
+++ b/prosemirror/model/to_dom.py
@@ -1,0 +1,173 @@
+from dataclasses import dataclass
+from typing import cast, Any, Callable, Dict, List, Optional, Tuple, Union
+
+from . import Fragment, Mark, Node, Schema
+
+
+HTMLNode = Union["Element", str]
+
+
+def escape_attr_value(s: str) -> str:
+    return s.replace('"', '\\"')
+
+
+@dataclass
+class DocumentFragment:
+    children: List[HTMLNode]
+
+    def __str__(self):
+        return "".join([str(c) for c in self.children])
+
+
+@dataclass
+class Element(DocumentFragment):
+    name: str
+    attrs: Dict[str, str]
+
+    def __str__(self):
+        attrs_str = " ".join(
+            [f'{k}="{escape_attr_value(v)}"' for k, v in self.attrs.items()]
+        )
+        children_str = "".join([str(c) for c in self.children])
+        open_tag_str = " ".join([s for s in [self.name, attrs_str] if s])
+        return f"<{open_tag_str}>{children_str}</{self.name}>"
+
+
+HTMLOutputSpec = Union[str, tuple, Element]
+
+
+@dataclass
+class DOMSerializer:
+    nodes: Dict[str, Callable[[Node], HTMLOutputSpec]]
+    marks: Dict[str, Callable[[Mark, bool], HTMLOutputSpec]]
+
+    def serialize_fragment(
+        self, fragment: Fragment, target: Optional[Element] = None
+    ) -> DocumentFragment:
+        tgt: DocumentFragment = target or DocumentFragment(children=[])
+
+        top = tgt
+        active: Optional[List[DocumentFragment]] = None
+
+        def each(node: Node, *_):
+            nonlocal top, active
+
+            if active or node.marks:
+                if not active:
+                    active = []
+                keep = 0
+                rendered = 0
+                while keep > len(active) and rendered < len(node.marks):
+                    next = node.marks[rendered]
+                    if next.type.name not in self.marks:
+                        rendered += 1
+                        continue
+                    if not next.eq(active[keep]) or next.type.spec.spanning is False:
+                        break
+                    keep += 2
+                    rendered += 1
+                while keep < len(active):
+                    top = active.pop()
+                    active.pop()
+                while rendered < len(node.marks):
+                    add = node.marks[rendered]
+                    rendered += 1
+                    mark_dom = self.serialize_mark(add, node.is_inline)
+                    if mark_dom:
+                        active.append(add)
+                        active.append(top)
+                        top.children.append(mark_dom[0])
+                        top = cast(DocumentFragment, mark_dom[1] or mark_dom[0])
+            top.children.append(self.serialize_node(node))
+
+        fragment.for_each(each)
+        return tgt
+
+    def serialize_node(self, node: Node) -> HTMLNode:
+        dom, content_dom = type(self).render_spec(self.nodes[node.type.name](node))
+        if content_dom:
+            if node.is_leaf:
+                raise Exception("Content hole not allowed in a leaf node spec")
+            self.serialize_fragment(node.content, content_dom)
+        return dom
+
+    def serialize_node_and_marks(self, node: Node) -> HTMLNode:
+        dom = self.serialize_node(node)
+        for mark in reversed(node.marks):
+            wrap = self.serialize_mark(mark, node.is_inline)
+            if wrap:
+                inner, content_dom = wrap
+                cast(DocumentFragment, content_dom or inner).children.append(dom)
+                dom = inner
+        return dom
+
+    def serialize_mark(
+        self, mark: Mark, inline: bool
+    ) -> Optional[Tuple[HTMLNode, Optional[Element]]]:
+        to_dom = self.marks[mark.type.name]
+        if to_dom:
+            return type(self).render_spec(to_dom(mark, inline))
+        return None
+
+    @classmethod
+    def render_spec(
+        cls, structure: HTMLOutputSpec
+    ) -> Tuple[HTMLNode, Optional[Element]]:
+        if isinstance(structure, str):
+            return structure, None
+        if isinstance(structure, Element):
+            return structure, None
+        tag_name = structure[0]
+        if " " in tag_name[1:]:
+            raise NotImplementedError("XML namespaces are not supported")
+        content_dom = None
+        dom = Element(name=tag_name, attrs={}, children=[])
+        attrs = structure[1] if len(structure) > 1 else None
+        start = 1
+        if isinstance(attrs, dict):
+            start = 2
+            for name, value in attrs.items():
+                if value is None:
+                    continue
+                if " " in name[1:]:
+                    raise NotImplementedError("XML namespaces are not supported")
+                dom.attrs[name] = value
+        for i in range(start, len(structure)):
+            child = structure[i]
+            if child == 0:
+                if i < len(structure) - 1 or i > start:
+                    raise Exception(
+                        "Content hole must be the only child of its parent node"
+                    )
+                return dom, dom
+            inner, inner_content = cls.render_spec(child)
+            dom.children.append(inner)
+            if inner_content:
+                if content_dom:
+                    raise Exception("Multiple content holes")
+                content_dom = inner_content
+        return dom, content_dom
+
+    @classmethod
+    def from_schema(cls, schema: Schema) -> "DOMSerializer":
+        return cls(cls.nodes_from_schema(schema), cls.marks_from_schema(schema))
+
+    @classmethod
+    def nodes_from_schema(cls, schema: Schema):
+        result = gather_to_dom(schema.nodes)
+        if "text" not in result:
+            result["text"] = lambda node: node.text
+        return result
+
+    @classmethod
+    def marks_from_schema(cls, schema: Schema):
+        return gather_to_dom(schema.marks)
+
+
+def gather_to_dom(obj: Dict[str, Any]):
+    result = {}
+    for name in obj:
+        to_dom = obj[name].get("spec", {}).get("toDOM")
+        if to_dom:
+            result[name] = to_dom
+    return result

--- a/prosemirror/schema/basic/schema_basic.py
+++ b/prosemirror/schema/basic/schema_basic.py
@@ -39,7 +39,7 @@ spec = {
                 {"tag": "h5", "attrs": {"level": 5}},
                 {"tag": "h6", "attrs": {"level": 6}},
             ],
-            "toDOM": lambda node: [f"h{node.attrs.level}", 0],
+            "toDOM": lambda node: [f"h{node.attrs['level']}", 0],
         },
         "code_block": {
             "content": "text*",

--- a/prosemirror/schema/basic/schema_basic.py
+++ b/prosemirror/schema/basic/schema_basic.py
@@ -1,5 +1,10 @@
 from prosemirror.model import Schema
 
+
+def const(obj):
+    return lambda *_, **__: obj
+
+
 spec = {
     "nodes": {
         "doc": {"content": "block+"},
@@ -7,14 +12,20 @@ spec = {
             "content": "inline*",
             "group": "block",
             "parseDOM": [{"tag": "p"}],
+            "toDOM": const(["p", 0]),
         },
         "blockquote": {
             "content": "block+",
             "group": "block",
             "defining": True,
             "parseDOM": [{"tag": "blockquote"}],
+            "toDOM": const(["blockquote", 0]),
         },
-        "horizontal_rule": {"group": "block", "parseDOM": [{"tag": "hr"}]},
+        "horizontal_rule": {
+            "group": "block",
+            "parseDOM": [{"tag": "hr"}],
+            "toDOM": const(["hr"]),
+        },
         "heading": {
             "attrs": {"level": {"default": 1}},
             "content": "inline*",
@@ -28,6 +39,7 @@ spec = {
                 {"tag": "h5", "attrs": {"level": 5}},
                 {"tag": "h6", "attrs": {"level": 6}},
             ],
+            "toDOM": lambda node: [f"h{node.attrs.level}", 0],
         },
         "code_block": {
             "content": "text*",
@@ -36,6 +48,7 @@ spec = {
             "code": True,
             "defining": True,
             "parseDOM": [{"tag": "pre", "preserveWhitespace": "full"}],
+            "toDOM": const(["pre", ["code", 0]]),
         },
         "text": {"group": "inline"},
         "image": {
@@ -44,28 +57,40 @@ spec = {
             "group": "inline",
             "draggable": True,
             "parseDOM": [{"tag": "img[src]"}],
+            "toDOM": lambda node: [
+                "img",
+                {
+                    "src": node.attrs["src"],
+                    "alt": node.attrs["alt"],
+                    "title": node.attrs["title"],
+                },
+            ],
         },
         "hard_break": {
             "inline": True,
             "group": "inline",
             "selectable": False,
             "parseDOM": [{"tag": "br"}],
+            "toDOM": const(["br"]),
         },
         "ordered_list": {
             "attrs": {"order": {"default": 1}},
             "parseDOM": [{"tag": "ol"}],
             "content": "list_item+",
             "group": "block",
+            "toDOM": const(["ol", 0]),
         },
         "bullet_list": {
             "parseDOM": [{"tag": "ul"}],
             "content": "list_item+",
             "group": "block",
+            "toDOM": const(["ul", 0]),
         },
         "list_item": {
             "parseDOM": [{"tag": "li"}],
             "defining": True,
             "content": "paragraph block*",
+            "toDOM": const(["li", 0]),
         },
     },
     "marks": {
@@ -73,14 +98,21 @@ spec = {
             "attrs": {"href": {}, "title": {"default": None}},
             "inclusive": False,
             "parseDOM": [{"tag": "a[href]"}],
+            "toDOM": lambda node, _: [
+                "a",
+                {"href": node.attrs["href"], "title": node.attrs["title"]},
+                0,
+            ],
         },
         "em": {
-            "parseDOM": [{"tag": "i"}, {"tag": "em"}, {"style": "font-style=italic"}]
+            "parseDOM": [{"tag": "i"}, {"tag": "em"}, {"style": "font-style=italic"}],
+            "toDOM": const(["em", 0]),
         },
         "strong": {
-            "parseDOM": [{"tag": "strong"}, {"tag": "b"}, {"style": "font-weight"}]
+            "parseDOM": [{"tag": "strong"}, {"tag": "b"}, {"style": "font-weight"}],
+            "toDOM": const(["strong", 0]),
         },
-        "code": {"parseDOM": [{"tag": "code"}]},
+        "code": {"parseDOM": [{"tag": "code"}], "toDOM": const(["code", 0])},
     },
 }
 

--- a/prosemirror/schema/list/schema_list.py
+++ b/prosemirror/schema/list/schema_list.py
@@ -7,11 +7,17 @@ UL_DOM = ["ul", 0]
 LI_DOM = ["li", 0]
 
 
-orderd_list = {"attrs": {"order": {"default": 1}}, "parseDOM": [{"tag": "ol"}]}
+orderd_list = {
+    "attrs": {"order": {"default": 1}},
+    "parseDOM": [{"tag": "ol"}],
+    "toDOM": lambda node: (
+        OL_DOM if node.attrs.get("order") == 1 else ["ol", {"start": node.attrs["order"]}, 0]
+    ),
+}
 
-bullet_list = {"parseDOM": [{"tag": "ul"}]}
+bullet_list = {"parseDOM": [{"tag": "ul"}], "toDOM": lambda _: UL_DOM}
 
-list_item = {"parseDOM": [{"tag": "li"}], "defining": True}
+list_item = {"parseDOM": [{"tag": "li"}], "defining": True, "toDOM": lambda _: LI_DOM}
 
 
 def add(obj, props):

--- a/tests/prosemirror_model/tests/test_dom.py
+++ b/tests/prosemirror_model/tests/test_dom.py
@@ -1,0 +1,54 @@
+import pytest
+
+from prosemirror.model import DOMSerializer
+from prosemirror.schema.basic import schema
+from prosemirror.test_builder import out
+
+doc = out["doc"]
+p = out["p"]
+li = out["li"]
+ul = out["ul"]
+em = out["em"]
+a = out["a"]
+blockquote = out["blockquote"]
+strong = out["strong"]
+code = out["code"]
+
+serializer = DOMSerializer.from_schema(schema)
+_marks_copy = serializer.marks.copy()
+del _marks_copy["em"]
+no_em = DOMSerializer(serializer.nodes, _marks_copy)
+
+
+@pytest.mark.parametrize(
+    "serializer,doc,expect,desc",
+    [
+        (
+            no_em,
+            p("foo", em("bar"), strong("baz")),
+            "foobar<strong>baz</strong>",
+            "it can omit a mark",
+        ),
+        (
+            no_em,
+            p("foo", code("bar"), em(code("baz"), "quux"), "xyz"),
+            "foo<code>barbaz</code>quuxxyz",
+            "it doesn't split other marks for omitted marks",
+        ),
+        (
+            DOMSerializer(
+                serializer.nodes,
+                {
+                    **serializer.marks,
+                    "em": lambda *_: ["em", ["i", {"data-emphasis": "true"}, 0]],
+                },
+            ),
+            p(strong("foo", code("bar"), em(code("baz"))), em("quux"), "xyz"),
+            "<strong>foo<code>bar</code></strong>"
+            '<em><i data-emphasis="true"><strong><code>baz</code></strong>quux</i></em>xyz',
+            "it can render marks with complex structure",
+        ),
+    ],
+)
+def test_serializer(serializer, doc, expect, desc):
+    assert str(serializer.serialize_fragment(doc.content)) == expect, desc

--- a/tests/prosemirror_model/tests/test_dom.py
+++ b/tests/prosemirror_model/tests/test_dom.py
@@ -34,12 +34,12 @@ no_em = DOMSerializer(serializer.nodes, _marks_copy)
         (
             "it can represent a line break",
             doc(p("hi", br, "there")),
-            "<p>hi<br/>there</p>",
+            "<p>hi<br>there</p>",
         ),
         (
             "it can represent an image",
             doc(p("hi", img({"alt": "x"}), "there")),
-            '<p>hi<img src="img.png" alt="x"/>there</p>',
+            '<p>hi<img src="img.png" alt="x">there</p>',
         ),
         (
             "it joins styles",

--- a/tests/prosemirror_model/tests/test_dom.py
+++ b/tests/prosemirror_model/tests/test_dom.py
@@ -13,6 +13,13 @@ a = out["a"]
 blockquote = out["blockquote"]
 strong = out["strong"]
 code = out["code"]
+img = out["img"]
+br = out["br"]
+ul = out["ul"]
+ol = out["ol"]
+h1 = out["h1"]
+h2 = out["h2"]
+pre = out["pre"]
 
 serializer = DOMSerializer.from_schema(schema)
 _marks_copy = serializer.marks.copy()
@@ -21,21 +28,104 @@ no_em = DOMSerializer(serializer.nodes, _marks_copy)
 
 
 @pytest.mark.parametrize(
-    "serializer,doc,expect,desc",
+    "desc,doc,html",
+    [
+        ("it can represent simple node", doc(p("hello")), "<p>hello</p>",),
+        (
+            "it can represent a line break",
+            doc(p("hi", br, "there")),
+            "<p>hi<br/>there</p>",
+        ),
+        (
+            "it can represent an image",
+            doc(p("hi", img({"alt": "x"}), "there")),
+            '<p>hi<img src="img.png" alt="x"/>there</p>',
+        ),
+        (
+            "it joins styles",
+            doc(p("one", strong("two", em("three")), em("four"), "five")),
+            "<p>one<strong>two</strong><em><strong>three</strong>four</em>five</p>",
+        ),
+        (
+            "it can represent links",
+            doc(
+                p(
+                    "a ",
+                    a({"href": "foo"}, "big ", a({"href": "bar"}, "nested"), " link"),
+                )
+            ),
+            '<p>a <a href="foo">big </a><a href="bar">nested</a><a href="foo"> link</a></p>',
+        ),
+        (
+            "it can represent an unordered list",
+            doc(
+                ul(li(p("one")), li(p("two")), li(p("three", strong("!")))), p("after")
+            ),
+            "<ul><li><p>one</p></li><li><p>two</p></li><li><p>three<strong>!</strong></p></li></ul><p>after</p>",
+        ),
+        (
+            "it can represent an ordered list",
+            doc(
+                ol(li(p("one")), li(p("two")), li(p("three", strong("!")))), p("after")
+            ),
+            "<ol><li><p>one</p></li><li><p>two</p></li><li><p>three<strong>!</strong></p></li></ol><p>after</p>",
+        ),
+        (
+            "it can represent a blockquote",
+            doc(blockquote(p("hello"), p("bye"))),
+            "<blockquote><p>hello</p><p>bye</p></blockquote>",
+        ),
+        (
+            "it can represent headings",
+            doc(h1("one"), h2("two"), p("text")),
+            "<h1>one</h1><h2>two</h2><p>text</p>",
+        ),
+        (
+            "it can represent inline code",
+            doc(p("text and ", code("code that is ", em("emphasized"), "..."))),
+            "<p>text and <code>code that is </code><em><code>emphasized</code></em><code>...</code></p>",
+        ),
+        (
+            "it can represent a code block",
+            doc(blockquote(pre("some code")), p("and")),
+            "<blockquote><pre><code>some code</code></pre></blockquote><p>and</p>",
+        ),
+        (
+            "it supports leaf nodes in marks",
+            doc(p(em("hi", br, "x"))),
+            "<p><em>hi<br>x</em></p>",
+        ),
+        (
+            "it doesn't collapse non-breaking spaces",
+            doc(p("\u00a0 \u00a0hello\u00a0")),
+            "<p>\u00a0 \u00a0hello\u00a0</p>",
+        ),
+    ],
+)
+def test_parser(doc, html, desc):
+    """Parser is not implemented, this is just testing serializer right now"""
+    schema = doc.type.schema
+    dom = DOMSerializer.from_schema(schema).serialize_fragment(doc.content)
+    assert str(dom) == html, desc
+
+
+@pytest.mark.parametrize(
+    "desc,serializer,doc,expect",
     [
         (
+            "it can omit a mark",
             no_em,
             p("foo", em("bar"), strong("baz")),
             "foobar<strong>baz</strong>",
-            "it can omit a mark",
         ),
         (
+            "it doesn't split other marks for omitted marks",
             no_em,
             p("foo", code("bar"), em(code("baz"), "quux"), "xyz"),
             "foo<code>barbaz</code>quuxxyz",
-            "it doesn't split other marks for omitted marks",
         ),
         (
+            "it can render marks with complex structure",
             DOMSerializer(
                 serializer.nodes,
                 {
@@ -46,7 +136,6 @@ no_em = DOMSerializer(serializer.nodes, _marks_copy)
             p(strong("foo", code("bar"), em(code("baz"))), em("quux"), "xyz"),
             "<strong>foo<code>bar</code></strong>"
             '<em><i data-emphasis="true"><strong><code>baz</code></strong>quux</i></em>xyz',
-            "it can render marks with complex structure",
         ),
     ],
 )


### PR DESCRIPTION
This PR adds a translation of [DOMSerializer][1]. It is exported from `prosemirror.model` but not `prosemirror`. Should it be available from the root of the package?

Currently it serializes down to a very dumbed-down DOM representation, since I didn't want to pull in a dependency and I didn't find a way to use `xml.dom` as an HTML document. Since the main use-case for this I can see is for generating a string of HTML for a node, I figured this would be enough (at least for now).

I ported the tests that deal with the serializer, and everything is passing with some minor modifications. Specifically, removing some slashes in cases like `<br/>`, which are not necessary in HTML (though it seems like I could have also had it always include the slash: [Void elements]).

[1]: https://github.com/ProseMirror/prosemirror-model/blob/master/src/to_dom.js
[Void elements]: https://dev.w3.org/html5/html-author/#void